### PR TITLE
Use setup option for setting dynamic client_options

### DIFF
--- a/lib/omniauth/strategies/atproto.rb
+++ b/lib/omniauth/strategies/atproto.rb
@@ -43,10 +43,6 @@ module OmniAuth
 
       private
 
-      def has_default_client_options?
-        %i[site authorize_url token_url].all? { |k| options.client_options.key? k }
-      end
-
       def build_access_token
         new_token_params = token_params.merge(
           {

--- a/lib/omniauth/strategies/atproto.rb
+++ b/lib/omniauth/strategies/atproto.rb
@@ -51,7 +51,7 @@ module OmniAuth
             code: request.params['code'],
             client_id: options.client_id,
             client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-            client_assertion: generate_client_assertion
+            client_assertion: generate_client_assertion,
           }
         )
         dpop_handler = AtProto::DpopHandler.new(options.private_key)

--- a/lib/omniauth/strategies/atproto.rb
+++ b/lib/omniauth/strategies/atproto.rb
@@ -19,21 +19,27 @@ module OmniAuth
         }
       end
 
-      def request_phase
-        unless has_default_client_options?
-          @handle = request.params['handle']
+      def self.setup
+        lambda do |env|
+          session = env["rack.session"]
 
-          unless @handle
-            fail!(:missing_handle,
-                  OmniAuth::Error.new(
-                    'Handle parameter is required if no client options are set'
-                  ))
+          if env["rack.request.form_hash"] && handle = env["rack.request.form_hash"]["handle"]
+            resolver = DIDKit::Resolver.new
+            did = resolver.resolve_handle(handle)
+            endpoint = resolver.resolve_did(did).pds_endpoint
+            auth_server = get_authorization_server(endpoint)
+            session["authorization_info"] = authorization_info = get_authorization_data(auth_server)
           end
-
-          set_client_options
+          
+          if authorization_info ||= session.delete("authorization_info")
+            env['omniauth.strategy'].options["client_options"]["site"] = authorization_info["issuer"]
+            env['omniauth.strategy'].options["client_options"]["authorize_url"] = authorization_info['authorization_endpoint']
+            env['omniauth.strategy'].options["client_options"]["token_url"] = authorization_info['token_endpoint']
+          end
         end
-        super
       end
+
+      option :setup, setup
 
       private
 
@@ -41,25 +47,7 @@ module OmniAuth
         %i[site authorize_url token_url].all? { |k| options.client_options.key? k }
       end
 
-      def set_client_options
-        options.client_options[:site] = authorization_info['issuer']
-        options.client_options[:authorize_url] = authorization_info['authorization_endpoint']
-        options.client_options[:token_url] = authorization_info['token_endpoint']
-      end
-
-      def authorization_info
-        session['omniauth.auth_info'] ||= begin
-          resolver = DIDKit::Resolver.new
-          did = resolver.resolve_handle(@handle)
-          endpoint = resolver.resolve_did(did).pds_endpoint
-          auth_server = get_authorization_server(endpoint)
-          auth_info = get_authorization_data(auth_server)
-        end
-      end
-
       def build_access_token
-        set_client_options unless has_default_client_options?
-
         new_token_params = token_params.merge(
           {
             grant_type: 'authorization_code',
@@ -115,7 +103,7 @@ module OmniAuth
         )
       end
 
-      def get_authorization_server(pds_endpoint)
+      def self.get_authorization_server(pds_endpoint)
         response = Faraday.get("#{pds_endpoint}/.well-known/oauth-protected-resource")
 
         unless response.success?
@@ -135,7 +123,7 @@ module OmniAuth
         auth_server
       end
 
-      def get_authorization_data(issuer)
+      def self.get_authorization_data(issuer)
         response = Faraday.get("#{issuer}/.well-known/oauth-authorization-server")
 
         unless response.success?

--- a/lib/omniauth/strategies/atproto.rb
+++ b/lib/omniauth/strategies/atproto.rb
@@ -26,6 +26,14 @@ module OmniAuth
           if env["rack.request.form_hash"] && handle = env["rack.request.form_hash"]["handle"]
             resolver = DIDKit::Resolver.new
             did = resolver.resolve_handle(handle)
+
+            unless did
+              env['omniauth.strategy'].fail!(:unknown_handle,
+                OmniAuth::Error.new(
+                  'Handle parameter did not resolve to a did'
+                ))
+            end
+
             endpoint = resolver.resolve_did(did).pds_endpoint
             auth_server = get_authorization_server(endpoint)
             session["authorization_info"] = authorization_info = get_authorization_data(auth_server)


### PR DESCRIPTION
Omniauth provides an [existing setup option](https://github.com/omniauth/omniauth/wiki/Dynamic-Providers) that can be used to configure dynamic client options.

Fixes #4 